### PR TITLE
Add support for firebase auth emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,14 @@ const withFirebaseUser: (
 interface WithFirebaseUserOptions {
   clientCertUrl?: string; // defaults to url provided in Firebase auth docs
   projectId?: string; // verifies the audience and issuer of the JWT when provided
+  isEmulator?: boolean; // defaults to false
 }
 ```
+
+## Contributing
+
+Feel free
+
+## License
+
+Do whatever you want with this code

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,3 +21,18 @@ export function fetchPublicKeys(
       });
   });
 }
+
+export function decodeJwtHeader(jwt: string) {
+  const [base64] = jwt.split('.');
+  const buffer = Buffer.from(base64, 'base64');
+  return buffer.toString();
+}
+
+export function getBearerToken(auth?: string) {
+  if (auth) {
+    const [scheme, credentials] = auth.split(' ');
+    if (scheme.toLocaleLowerCase() === 'bearer') {
+      return credentials;
+    }
+  }
+}

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -1,8 +1,0 @@
-export function getBearerToken(auth?: string) {
-  if (auth) {
-    const [scheme, credentials] = auth.split(' ');
-    if (scheme.toLocaleLowerCase() === 'bearer') {
-      return credentials;
-    }
-  }
-}

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,5 +1,0 @@
-export function decodeJwtHeader(jwt: string) {
-  const [base64] = jwt.split('.');
-  const buffer = Buffer.from(base64, 'base64');
-  return buffer.toString();
-}

--- a/src/withFirebaseUser.ts
+++ b/src/withFirebaseUser.ts
@@ -1,16 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { NextApiRequestWithFirebaseUser, FirebaseUser } from './types';
-import jwt from 'jsonwebtoken';
-import { getBearerToken } from './utils/headers';
-import { decodeJwtHeader } from './utils/jwt';
-import { fetchPublicKeys } from './utils/fetchPublicKeys';
+import jwt, { JwtPayload } from 'jsonwebtoken';
+import { getBearerToken, decodeJwtHeader, fetchPublicKeys } from './utils';
 
-const FIREBASE_AUTH_CERT_URL =
-  'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com';
 interface WithFirebaseUserOptions {
   clientCertUrl?: string;
   projectId?: string;
+  isEmulator: boolean;
 }
+
+const FIREBASE_AUTH_CERT_URL =
+  'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com';
 
 export const withFirebaseUser =
   (
@@ -22,15 +22,16 @@ export const withFirebaseUser =
   ) =>
   async (req: NextApiRequest, res: NextApiResponse) => {
     // merge options with defaults
-    const { projectId, clientCertUrl } = Object.assign(
+    const { projectId, clientCertUrl, isEmulator } = Object.assign(
       {},
       {
         clientCertUrl: FIREBASE_AUTH_CERT_URL,
+        isEmulator: false,
       },
       options
     );
 
-    // copy request object for decoration with firebase user
+    // copy request object
     const decoratedReq: NextApiRequestWithFirebaseUser = Object.assign(
       {},
       req,
@@ -53,14 +54,19 @@ export const withFirebaseUser =
 
       const publicKey = publicKeys[jwtHeader.kid];
       if (publicKey) {
-        // decode jwt with public key
-        const decodedToken = jwt.verify(accessToken, publicKey, {
-          audience: projectId,
-          issuer: projectId && `https://securetoken.google.com/${projectId}`,
-        });
+        let decodedToken: string | JwtPayload | null;
 
-        if (typeof decodedToken === 'object') {
-          // create user object we decorate req with from decoded token
+        if (isEmulator) {
+          decodedToken = jwt.decode(accessToken);
+        } else {
+          decodedToken = jwt.verify(accessToken, publicKey, {
+            audience: projectId,
+            issuer: projectId && `https://securetoken.google.com/${projectId}`,
+          });
+        }
+
+        if (typeof decodedToken === 'object' && decodedToken !== null) {
+          // might want to support custom claims in the future
           const user: FirebaseUser = {
             user_id: decodedToken.user_id ?? decodedToken.sub,
             name: decodedToken.name,
@@ -72,7 +78,7 @@ export const withFirebaseUser =
         }
       }
     } catch (err) {
-      console.info('withFirebaseUser: ', err);
+      console.error('withFirebaseUser: ', err);
     }
 
     return handler(decoratedReq, res);


### PR DESCRIPTION
### Changes
- Adds isEmulator option to support firebase auth emulator

### Notes
Uses `jwt.decode` for emulator tokens instead of actually trying to verify them. 

I'm realizing it might be a pain to configure options for every api route that you wrap with `withFirebaseUser`. Maybe I should add an initialize function that returns the `withFirebaseUser` HOF with the options applied so this only needs to be done once. This would be a breaking change.

### Testing
I have not tested this yet. Going to make sure it works before I merge and publish to npm

Closes #2 